### PR TITLE
Added mcp-vegalite-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://qdrant.tech/img/brand-resources-logos/logomark.svg" height="14"/> [Qdrant](https://github.com/qdrant/mcp-server-qdrant/)<sup><sup>⭐</sup></sup> - A Qdrant MCP server for keeping and retrieving memories in the Qdrant vector search engine.
 - <img src="https://cdn.simpleicons.org/mongodb/47A248" height="14"/> [MongoDB](https://github.com/kiliczsh/mcp-mongo-server) - A Model Context Protocol Server for querying and analyzing MongoDB collections.
 - <img src="https://cdn.simpleicons.org/mysql" height="14"/> [MySQL](https://github.com/designcomputer/mysql_mcp_server) - MySQL database integration with configurable access controls and schema inspection
+- <img src="https://vega.github.io/favicon.ico" height="14"/> [VegaLite](https://github.com/isaacwasserman/mcp-vegalite-server) - Generate visualizations from fetched data using the VegaLite format and renderer
 
 <br />
 


### PR DESCRIPTION
The current list of community servers has lots of data sources but seems to be missing any sort of data visualization tools. While Claude Desktop natively renders Recharts visualizations well, it would be beneficial to have a way to produce charts in a canonical MCP-like way (especially for alternative clients). mcp-vegalite-server meets this requirement.