### PR TITLE
Update README.md to include Make MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A curated list of awesome Model Context Protocol (MCP) servers. MCP is an open p
 - 🎯 - [Marketing](#marketing)
 - 📝 - [Note Taking](#note-taking)
 - ⚡ - [Cloud Platforms](#cloud-platforms)
+- ⚙️ - [Workflow Automation](#workflow-automation)
 - 🤖 - [System Automation](#system-automation)
 - 📱 - [Social Media](#social-media)
 - 💹 - [Finance](#finance)
@@ -185,6 +186,14 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/cloudflare/F38020" height="14"/> [Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)<sup><sup>⭐</sup></sup> - Integration with Cloudflare services including Workers, KV, R2, and D1
 - <img src="https://cdn.simpleicons.org/kubernetes/326CE5" height="14"/> [Kubernetes](https://github.com/strowk/mcp-k8s-go) - Kubernetes cluster operations through MCP
 - <img src="https://tinybird.co/favicon.ico" height="14"/> [Tinybird](https://github.com/tinybirdco/mcp-tinybird)<sup><sup>⭐</sup></sup> - Interact with a Tinybird Workspace from any MCP client.
+
+<br />
+
+## ⚙️ <a name="workflow-automation"></a>Workflow Automation
+
+> Integration with workflow automation platforms allows AI models to execute workflows and retrieve data back to their systems.
+
+- <img src="https://www.make.com/favicon.ico" height="14"/> [Make](https://github.com/integromat/make-mcp-server)<sup><sup>⭐</sup></sup> - Turn Make scenarios into callable tools for AI assistants.
 
 <br />
 


### PR DESCRIPTION
Adds a link to the Make MCP server repo in the README. Since I couldn’t find a fitting category, I suggested adding the "Workflow Automation" category.