### PR TITLE
Add intlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://github.com/user-attachments/assets/9d517481-c4cd-4b6c-903a-878531c9d881" height="14" /> [Bucket](https://github.com/bucketco/bucket-javascript-sdk/tree/main/packages/cli#model-context-protocol) - Flag features, manage company data, and control feature access using [Bucket](https://bucket.co)
 - <img src="https://edgeone.ai/favicon.ico" height="14" /> [EdgeOne Pages](https://github.com/TencentEdgeOne/edgeone-pages-mcp) - A MCP service for deploying HTML content to EdgeOne Pages and obtaining a publicly accessible URL.
 - <img src="https://cdn.jsdelivr.net/gh/jsdelivr/globalping-media@refs/heads/master/icons/android-chrome-192x192.png" height="14" /> [Globalping MCP](https://github.com/jsdelivr/globalping-mcp-server)<sup><sup>⭐</sup></sup> - Access a network of thousands of probes to run network commands like ping, traceroute, mtr, http and DNS resolve.
+-  <img src="[https://intayer.org/fav](https://intlayer.org/favicon-32x32.png)" height="14" /> [aymericzip/intlayer](https://github.com/aymericzip/intlayer) - A MCP Server that enhance your IDE with AI-powered assistance for Intlayer i18n / CMS tool: smart CLI access, docs.
 
 <br />
 


### PR DESCRIPTION
# [@intlayer/mcp](https://www.npmjs.com/package/@intlayer/mcp) – MCP server for i18n / CMS solution 

The `@intlayer/mcp` server offers seamless IDE integration for developers using [Intlayer](https://github.com/aymericzip/intlayer), an internationalization library tailored for modern JavaScript and TypeScript projects using AI.

By connecting your IDE to this MCP server (e.g., in [Cursor](https://www.cursor.so)), you get instant access to:

 **CLI integration** – Inline guidance and command completion for Intlayer’s CLI tooling. (list / build / pull / push / fill dictionaries)
***Integrated access to the documentation** – Provide access to the Intlayer doc to the IDE

 – To add into your `.cursor/mcp.json`.

Ideal for teams working with multilingual content, component-based architectures, and modern frameworks like Next.js. Perfectly bridges AI and content localization.

Doc: https://intlayer.org/doc/mcp-server 