### PR TITLE
feat: Add OpenNutrition MCP Server to Research & Data Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 - <img src="https://cdn.simpleicons.org/arxiv/B31B1B" height="14"/> [ArXiv](https://github.com/blazickjp/arxiv-mcp-server) - Search ArXiv research papers
 - <img src="https://api.iconify.design/mdi:dna.svg?color=%23E34234" height="14"/> [Ancestry](https://github.com/reeeeemo/ancestry-mcp) - Read .ged files and genetic data
+- <img src="https://cdn.simpleicons.org/apple/7ED957" height="14"/> [OpenNutrition](https://github.com/deadletterq/mcp-opennutrition) - Search 300,000+ foods, nutrition facts, and barcodes from the OpenNutrition database
 
 <br />
 


### PR DESCRIPTION
Add the OpenNutrition MCP server to the "Research & Data" section of the README.

- Provided a description in line with the README style.
- Ensured the entry includes an appropriate icon and matches the formatting of other listed MCP servers.