### PR TITLE
Add Maven Tools MCP to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://gitkraken.com/favicon.ico" height="14" /> [GitKraken](https://github.com/gitkraken/gk-cli)<sup><sup>⭐</sup></sup> - A CLI for interacting with GitKraken APIs. Includes an MCP server via gk mcp that not only wraps GitKraken APIs, but also Jira, GitHub, GitLab, and more. Works with local tools and remote services.
 -  <img src="[https://intayer.org/fav](https://intlayer.org/favicon-32x32.png)" height="14" /> [aymericzip/intlayer](https://github.com/aymericzip/intlayer) - A MCP Server that enhance your IDE with AI-powered assistance for Intlayer i18n / CMS tool: smart CLI access, docs.
 - <img src="https://cdn.simpleicons.org/jira/0052CC" height="14"/> [tom28881/mcp-jira-server](https://github.com/tom28881/mcp-jira-server) - Comprehensive TypeScript MCP server for Jira with 20+ tools covering complete project management workflow: issue CRUD, sprint management, comments/history, attachments, batch operations. Features universal field auto-detection, full Czech/localization support, and date parsing with multiple formats. Created by [Tomáš Gregorovič](https://www.linkedin.com/in/tomáš-g-8423b61a2/).
+- ☕ [Maven Tools MCP](https://github.com/arvindand/maven-tools-mcp) - Maven Central dependency intelligence for JVM build tools (Maven, Gradle, SBT, Mill) with Context7 integration for documentation support.
 
 <br />
 


### PR DESCRIPTION
## Summary

Add Maven Tools MCP server to the Development Tools section.

## Details

- **Category**: Development Tools (most appropriate for JVM build tools)
- **Position**: Added to bottom of section as per contribution guidelines

## Server Overview

**Maven Tools MCP** provides Maven Central dependency intelligence for JVM build tools:

- Support for Maven, Gradle, SBT, Mill, and other JVM build systems
- Context7 integration for documentation support
- Dependency analysis, version checking, and project health assessment
- Multi-platform support (macOS, Windows, Linux)

**Repository**: https://github.com/arvindand/maven-tools-mcp  
**Docker**: `arvindand/maven-tools-mcp:latest`