### PR TITLE
feat: Add Carbon Voice official MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://www.line.me/favicon-32x32.png" height="14" /> [LINE Official Account](https://github.com/line/line-bot-mcp-server)<sup><sup>⭐</sup></sup> - Integrates the LINE Messaging API to connect an AI Agent to the LINE Official Account.
 - <img src="https://cdn.simpleicons.org/linear/5E6AD2" height="14"/> [Linear](https://github.com/jerhadf/linear-mcp-server) - Linear MCP Server. Provides integration with Linear's issue tracking system through MCP.
 - <img src="https://cdn.simpleicons.org/atlassian/0052CC" height="14"/> [Atlassian](https://github.com/sooperset/mcp-atlassian) - Comprehensive integration with Atlassian suite including Confluence for documentation management and Jira for issue tracking.
+- <img src="https://carbonvoice.app/favicon.ico" height="14"/> [Carbon Voice](https://github.com/PhononX/cv-mcp-server)<sup><sup>⭐</sup></sup> - MCP Server that connects AI Agents to [Carbon Voice](https://getcarbon.app). Create, manage, and interact with voice messages, conversations, direct messages, folders, voice memos, AI actions and more in [Carbon Voice](https://getcarbon.app).
 - <img src="https://m2tg1pnwn0.ufs.sh/f/GMqNN8nd9I8l9tUbmif1CnFX8Baqr7mHeicYu0AULDyNVWJE" height="14"/> [ntfy](https://github.com/gitmotion/ntfy-me-mcp) - An ntfy MCP server for sending/fetching ntfy notifications to your self-hosted ntfy.sh server from AI Agents 📤 (supports secure token auth & more - use with npx or docker!)
 
 <br />


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
MCP Server official implementation developed by the Carbon Voice team to enable LLMs to access tools for [Carbon Voice Platform](https://getcarbon.app).

## Motivation and Context
Enable AI assistants and LLMs to seamlessly integrate with Carbon Voice's voice messaging platform, providing comprehensive access to voice conversations, message management, and AI-powered content processing capabilities.

## How Has This Been Tested?
- [x] Each tool on the MCP server has been manually tested within:
  - [x] Claude Desktop
  - [x] Claude AI
  - [x] Cursor
