### PR TITLE
Add Agent Mindshare to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 > Tools that help marketers write better content and run better campaigns.
 
+- <img src="https://cdn.simpleicons.org/analytics/4285F4" height="14"/> [Agent Mindshare](https://agentmindshare.com) - Track and monitor AI agent mindshare across platforms - measure brand visibility in AI conversations.
 - <img src="https://openstrategypartners.com/fileadmin/Bilder/logo/OSP_logo_colors_green1.png" height="14"/> [Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools)<sup><sup>⭐</sup></sup> - a standardized editing code system, writing guidelines, web metadata generator, and product communication framework.
 - <img src="https://cdn.simpleicons.org/fathom/9187FF" height="14"/> [Fathom Analytics](https://github.com/mackenly/mcp-fathom-analytics) - Access Fathom Analytics data and reports about your sites
 - <img src="https://static.xx.fbcdn.net/rsrc.php/y9/r/tL_v571NdZ0.svg" height="14"/> [Facebook Ads](https://github.com/gomarble-ai/facebook-ads-mcp-server) - MCP server acting as an interface to the Facebook Ads, enabling programmatic access to Facebook Ads data and management features.


### PR DESCRIPTION
## Summary

- Added Agent Mindshare to the Marketing section in alphabetical order
- Agent Mindshare is a remote MCP service that tracks and monitors AI agent mindshare across platforms
- Helps measure brand visibility in AI conversations

## Test plan

- [x] Verified Agent Mindshare entry follows the repository's formatting style with icon
- [x] Positioned alphabetically at the beginning of Marketing section
- [x] Used appropriate analytics icon for the service
- [x] Followed link format convention

🤖 Generated with [Claude Code](https://claude.ai/code)