### PR TITLE
docs: add AI Manifest + WellKnownAI (optional references)

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,3 +519,10 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Stephen Akinyemi](https://github.com/appcypher) has waived all copyright and related or neighboring rights to this work.
+
+
+## Links
+
+<!-- ai-manifest-ref 2025-09-20T13:27:31.074Z -->
+- [AI Manifest](https://ai-manifest.org) - Optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping)
+- [WellKnownAI](https://wellknownai.org) - Registry/spec examples and public snapshots (no PII; mirroring allowed)


### PR DESCRIPTION
Adds two optional references under "Links". Non-binding; happy to adjust section title or wording.

- AI Manifest — optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping). https://ai-manifest.org
- WellKnownAI — registry/spec examples and public snapshots (no PII; mirroring allowed). https://wellknownai.org

Alphabetical order respected where applicable.