### PR TITLE
Add secretctl to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CAKM](https://github.com/sanyambassi/thales-cdsp-cakm-mcp-server) - MCP server for Thales CDSP CAKM integration, enabling secure key management, cryptographic operations, and compliance monitoring through AI assistants for Ms SQL and Oracle Databases.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CRDP](https://github.com/sanyambassi/thales-cdsp-crdp-mcp-server) - MCP server for Thales CipherTrust Manager RestFul Data Protection service.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CSM](https://github.com/sanyambassi/thales-cdsp-csm-mcp-server) - MCP server for Thales CipherTrust Secrets Management
+- <img src="https://cdn.simpleicons.org/gnuprivacyguard/0093DD" height="14"/> [secretctl](https://github.com/forest6511/secretctl) - AI-safe secrets manager with MCP support. AI agents can use secrets via environment injection without ever seeing plaintext values.
 
 <br />
 


### PR DESCRIPTION
## Summary

Add [secretctl](https://github.com/forest6511/secretctl) to the Security section.

secretctl is an AI-safe secrets manager with MCP support. AI agents can use secrets via environment injection without ever seeing plaintext values.

**Key features:**
- Local-first, single-binary secrets management
- AES-256-GCM encryption with Argon2id key derivation
- MCP tools for AI-safe secret access (`secret_list`, `secret_run`, `secret_get_masked`)
- Comprehensive audit logging
- Desktop app with React/TypeScript frontend

## Checklist

- [x] Entry added to the bottom of Security section
- [x] Format follows existing patterns
- [x] Link is valid and points to an active repository