### PR TITLE
Add sudo-mcp to System Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Windows_logo_-_2021.svg/1024px-Windows_logo_-_2021.svg.png" height="14"/> [Windows Control](https://github.com/Cheffromspace/nutjs-windows-control) - Windows automation MCP server providing mouse, keyboard, screen capture, clipboard, and window management capabilities using NutJS.
 - <img src="https://cdn.simpleicons.org/gnometerminal/2196F3" height="14"/> [Command Line](https://github.com/phialsbasement/cmd-mcp-server) - MCP server allowing any and all command execution over CMD(BE CAREFUL).
 - <img src="https://cdn.simpleicons.org/apple/999999" height="14"/> [Apple Shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts) - An MCP Server Integration with Apple Shortcuts
+- <img src="https://cdn.simpleicons.org/linux/FCC624" height="14"/> [sudo-mcp](https://github.com/hughesjs/sudo-mcp) - Allows your LLM to run commands with sudo using polkit for privilege escalation
 
 <br />
 


### PR DESCRIPTION
## Description
Adds sudo-mcp to the System Automation category.

## About sudo-mcp
sudo-mcp allows LLMs to run commands with sudo using polkit for privilege escalation, providing secure elevated privilege access for AI agents.

**Repository**: https://github.com/hughesjs/sudo-mcp

## Checklist
- [x] Searched for duplicates
- [x] Added to bottom of relevant category (System Automation)
- [x] Individual PR for single server
- [x] Checked spelling and grammar
- [x] Removed trailing whitespace
- [x] Clear, descriptive addition