### PR TITLE
Add Mantora MCP to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/jira/0052CC" height="14"/> [tom28881/mcp-jira-server](https://github.com/tom28881/mcp-jira-server) - Comprehensive TypeScript MCP server for Jira with 20+ tools covering complete project management workflow: issue CRUD, sprint management, comments/history, attachments, batch operations. Features universal field auto-detection, full Czech/localization support, and date parsing with multiple formats. Created by [Tomáš Gregorovič](https://www.linkedin.com/in/tomáš-g-8423b61a2/).
 - <img src="https://maven.apache.org/images/maven-logo-black-on-white.png" height="14"/>  [Maven Tools MCP](https://github.com/arvindand/maven-tools-mcp) - Maven Central dependency intelligence for JVM build tools (Maven, Gradle, SBT, Mill) with Context7 integration for documentation support.
 - <img src="https://defang.io/favicon.png" height="14" /> [DefangLabs/defang](https://github.com/DefangLabs/defang) - CLI and MCP server for building and deploying Docker Compose-compatible projects to your own AWS, GCP, or DigitalOcean account.
-- <img src="https://github.com/josephwibowo.png" height="14"/> [Mantora](https://github.com/josephwibowo/mantora-mcp) - A local-first MCP observer: a lightweight UI + proxy for inspecting LLM data access (sessions, tool calls, results) with protective defaults.
+- <img src="https://github.com/josephwibowo.png" height="14"/> [Mantora](https://github.com/josephwibowo/mantora) - A local-first MCP observer: a lightweight UI + proxy for inspecting LLM data access (sessions, tool calls, results) with protective defaults.
 
 <br />
 


### PR DESCRIPTION
Adds **Mantora MCP** to the Developer Tools list. Mantora provides a lightweight UI and proxy for inspecting LLM data access (sessions, tool calls, results) with protective defaults.
https://github.com/josephwibowo/mantora
