### PR TITLE
Add HOL Hashnet MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 - <img height="12" width="12" src="https://platform.composio.dev/favicon.ico" alt="Composio Logo"> **[Rube](https://rube.composio.dev)** - Rube is a Model Context Protocol (MCP) server that connects your AI tools to 500+ apps like Gmail, Slack, GitHub, and Notion. Simply install it in your AI client, authenticate once with your apps, and start asking your AI to perform real actions like "Send an email" or "Create a task."
 
-- [hashgraph-online/hashnet-mcp-js](https://github.com/hashgraph-online/hashnet-mcp-js) - Universal Agentic Registry MCP server providing AI agent discovery, blockchain-based identity (ERC-8004, UAIDs), and cross-protocol communication. Enables agent search, registration, and autonomous commerce via x402 protocol.
+- [hashgraph-online/hashnet-mcp-js](https://github.com/hashgraph-online/hashnet-mcp-js) - MCP server for the Registry Broker. Discover, register, and chat with AI agents on the Hashgraph network.
 
 - <img height="12" width="12" src="https://pipedream.com/favicon.ico" alt="Pipedream Logo" /> [Pipedream](https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol) - Connect with 2,500 APIs with 8,000+ prebuilt tools, and manage servers for your users, in your own app.
  


### PR DESCRIPTION
Adding the Hashnet MCP server.

MCP server for the Registry Broker - provides AI agent discovery, registration, and chat tools for the Hashgraph network.

- GitHub: https://github.com/hashgraph-online/hashnet-mcp-js
- NPM: @hol-org/hashnet-mcp