### PR TITLE
Add Coupang MCP and Naver Search MCP (Korean services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://framerusercontent.com/images/0Bw7GwbNXUBxOAp9pyM0VPOlphg.png" height="14" /> [Skyvern](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/mcp) - MCP to let Claude or your own LLM control your browser
 - <img src="https://searx.space/favicon.png" height="14" /> [Ihor-Sokoliuk/MCP-SearXNG](https://github.com/ihor-sokoliuk/mcp-searxng) - A Model Context Protocol Server for [SearXNG](https://docs.searxng.org)
 - <img src="https://pragmar.com/media/static/images/mcp-server-webcrawl/favicon.png" height="14" /> [mcp-server-webcrawl](https://github.com/pragmar/mcp-server-webcrawl) - Advanced search and retrieval for web crawler data. Supports WARC, wget, Katana, SiteOne, and InterroBot crawlers.
+- 🛒 [Coupang MCP](https://github.com/uju777/coupang-mcp) - MCP server for Coupang (Korea's largest e-commerce) product search with Rocket Delivery filtering
+- 🇰🇷 [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - MCP server for Naver Search (Shopping, Cafe, News). Essential for Korean users.
 
 <br />
 


### PR DESCRIPTION
## Summary
Adding two Korean service MCP servers to the Search & Web section.

## Added Servers

### 1. Coupang MCP
- Korea's largest e-commerce platform search
- Rocket Delivery filtering
- Price comparison
- https://github.com/uju777/coupang-mcp

### 2. Naver Search MCP  
- Naver Shopping search
- Naver Cafe search
- Naver News search
- Essential for Korean users
- https://github.com/uju777/mcp-server-naver-search