### PR TITLE
Add AgentKits Marketing to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/fathom/9187FF" height="14"/> [Fathom Analytics](https://github.com/mackenly/mcp-fathom-analytics) - Access Fathom Analytics data and reports about your sites
 - <img src="https://static.xx.fbcdn.net/rsrc.php/y9/r/tL_v571NdZ0.svg" height="14"/> [Facebook Ads](https://github.com/gomarble-ai/facebook-ads-mcp-server) - MCP server acting as an interface to the Facebook Ads, enabling programmatic access to Facebook Ads data and management features.
 - <img src="https://img.icons8.com/?size=48&id=ui4CTPMMDCFh&format=png" height="14"/> [Google Ads](https://github.com/gomarble-ai/google-ads-mcp-server) - MCP server acting as an interface to the Google Ads, enabling programmatic access to Google Ads data and management features.
+- [AgentKits Marketing](https://github.com/aitytech/agentkits-marketing) - Complete AI marketing toolkit with 18 specialized agents, 93 slash commands, and 28 marketing skills for SEO, CRO, copywriting, email sequences, and competitive analysis. Works with Claude Code, Cursor, and Windsurf.
 <br />
 
 ## 📝 <a name="note-taking"></a>Note Taking


### PR DESCRIPTION
Adding AgentKits Marketing to the Marketing section.

Complete AI marketing toolkit with 18 specialized agents, 93 slash commands, and 28 marketing skills for SEO, CRO, copywriting, email sequences, and competitive analysis. Works with Claude Code, Cursor, and Windsurf.

- **GitHub:** https://github.com/aitytech/agentkits-marketing
- **License:** MIT