### PR TITLE
Add danishashko/make-mcp as second Make.com MCP implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 > Integration with workflow automation platforms allows AI models to execute workflows and retrieve data back to their systems.
 
 - <img src="https://www.make.com/favicon.ico" height="14"/> [Make](https://github.com/integromat/make-mcp-server)<sup><sup>⭐</sup></sup> - Turn Make scenarios into callable tools for AI assistants.
+- <img src="https://www.make.com/favicon.ico" height="14"/> [make-mcp-server](https://github.com/danishashko/make-mcp)<sup><sup>2</sup></sup> - Unofficial community fork with 200+ modules, auto-healing blueprints, and router support for building Make.com scenarios via AI.
 - <img src="https://www.taskade.com/favicon.ico" height="14"/> [Taskade MCP](https://github.com/taskade/mcp)<sup><sup>⭐</sup></sup> - Official Taskade MCP server + OpenAPI → MCP codegen to build AI agent tools from any API and connect Taskade to Claude, Cursor, and more.
 
 <br />
@@ -519,3 +520,4 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Stephen Akinyemi](https://github.com/appcypher) has waived all copyright and related or neighboring rights to this work.
+


### PR DESCRIPTION
This PR adds [danishashko/make-mcp](https://github.com/danishashko/make-mcp) as a second implementation of the Make.com MCP server in the Workflow Automation section.

**Key Features:**
- 200+ modules with comprehensive documentation
- Auto-healing blueprint validation
- Router support for complex workflows
- Build and validate Make.com scenarios via AI

This is an unofficial community fork that provides additional functionality alongside the official Make.com implementation.