### PR TITLE
Add wc26-mcp — FIFA World Cup 2026 data server

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://probe.dev/favicon.ico" height="14"/> [Probe.dev](https://mcp.probe.dev) - Professional media analysis and validation MCP server with FFprobe, MediaInfo, and comprehensive reporting capabilities
 - <img src="https://cdn.simpleicons.org/apple/7ED957" height="14"/> [OpenNutrition](https://github.com/deadletterq/mcp-opennutrition) - Search 300,000+ foods, nutrition facts, and barcodes from the OpenNutrition database
 - <img src="https://congressmcp.lawgiver.ai/favicon.svg" height="14"/> [Congress](https://github.com/amurshak/congressMCP) - Query and reeason about legislative data from Congress.gov
+- ⚽ [wc26-mcp](https://github.com/jordanlyall/wc26-mcp) - FIFA World Cup 2026 data — matches, teams, venues, city guides, fan zones, visa requirements, and more. Zero API keys required.
 
 <br />
 


### PR DESCRIPTION
## Summary
- Adds [wc26-mcp](https://github.com/jordanlyall/wc26-mcp) to the **Research & Data** section
- FIFA World Cup 2026 MCP server with 12 tools covering matches, teams, venues, city guides, fan zones, visa requirements, and more
- Zero API keys required — all data is bundled statically
- Published on npm as `wc26-mcp` (runnable via `npx wc26-mcp`)
- Website: https://wc26.ai