### PR TITLE
Add ResearchTwin to Research & Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/apple/7ED957" height="14"/> [OpenNutrition](https://github.com/deadletterq/mcp-opennutrition) - Search 300,000+ foods, nutrition facts, and barcodes from the OpenNutrition database
 - <img src="https://congressmcp.lawgiver.ai/favicon.svg" height="14"/> [Congress](https://github.com/amurshak/congressMCP) - Query and reeason about legislative data from Congress.gov
 
+- <img src="https://researchtwin.net/assets/app-icon-1024.png" height="14"/> [ResearchTwin](https://github.com/martinfrasch/researchtwin/tree/master/mcp-server) - Federated research discovery with S-Index metrics across Semantic Scholar, Google Scholar, GitHub, and Figshare
 <br />
 
 ## 🤝 <a name="ai-services"></a>AI Services


### PR DESCRIPTION
Adds [ResearchTwin](https://researchtwin.net) MCP server to the Research & Data section.

ResearchTwin is a federated platform for inter-agentic research discovery. The MCP server exposes 8 tools for AI agents to discover researchers, publications (Semantic Scholar + Google Scholar), datasets (Figshare), repositories (GitHub), and S-Index impact metrics.

- **Source**: https://github.com/martinfrasch/researchtwin/tree/master/mcp-server
- **Language**: Python
- **Transport**: stdio
- **API**: https://researchtwin.net/.well-known/openapi.json