### PR TITLE
Add Janee to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CAKM](https://github.com/sanyambassi/thales-cdsp-cakm-mcp-server) - MCP server for Thales CDSP CAKM integration, enabling secure key management, cryptographic operations, and compliance monitoring through AI assistants for Ms SQL and Oracle Databases.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CRDP](https://github.com/sanyambassi/thales-cdsp-crdp-mcp-server) - MCP server for Thales CipherTrust Manager RestFul Data Protection service.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CSM](https://github.com/sanyambassi/thales-cdsp-csm-mcp-server) - MCP server for Thales CipherTrust Secrets Management
+- [Janee](https://github.com/rsdouglas/janee) - Secrets management MCP server for AI agents. Store API keys encrypted locally, agents request access via MCP tools, keys are injected without agent exposure. Full audit logging, time-limited sessions, and revocable access.
 
 <br />
 


### PR DESCRIPTION
## Add Janee - Secrets Management MCP Server

Adds [Janee](https://github.com/rsdouglas/janee) to the Security section.

**What it does:** Janee is an MCP server that manages API secrets for AI agents. Instead of giving agents raw API keys, Janee stores them encrypted locally and injects credentials at request time — agents never see the actual keys.

**Key features:**
- AES-256-GCM encrypted credential storage
- Just-in-time credential injection via MCP tools
- Full audit logging of every API request
- Time-limited, revocable sessions
- Works with Claude Desktop, Cursor, and any MCP client

**Published on npm:** [@true-and-useful/janee](https://www.npmjs.com/package/@true-and-useful/janee)

Placed alphabetically in the Security section per contribution guidelines.