### PR TITLE
Add Janee - secrets management MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CAKM](https://github.com/sanyambassi/thales-cdsp-cakm-mcp-server) - MCP server for Thales CDSP CAKM integration, enabling secure key management, cryptographic operations, and compliance monitoring through AI assistants for Ms SQL and Oracle Databases.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CRDP](https://github.com/sanyambassi/thales-cdsp-crdp-mcp-server) - MCP server for Thales CipherTrust Manager RestFul Data Protection service.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CSM](https://github.com/sanyambassi/thales-cdsp-csm-mcp-server) - MCP server for Thales CipherTrust Secrets Management
+- [Janee](https://github.com/rsdouglas/janee) - Secrets management MCP server for AI agents. Acts as a secure proxy so agents get capability-scoped, auditable access to external services without ever seeing raw API keys or credentials.
 
 <br />
 


### PR DESCRIPTION
Adds [Janee](https://github.com/rsdouglas/janee) to the Security section.

**What it does:** Janee is a secrets management MCP server for AI agents. It acts as a secure proxy — agents get capability-scoped, auditable access to external services without ever seeing raw API keys or credentials.

**Why it belongs here:** As MCP adoption grows, secure secrets handling is critical. Most MCP servers require API keys via environment variables, exposing them to any agent. Janee solves this with a proxy-based approach.

- MIT licensed
- Published on npm: `@true-and-useful/janee`
- Active development with plugin architecture (OpenClaw)