### PR TITLE
Add Janee to Security section - MCP-native secrets management

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CAKM](https://github.com/sanyambassi/thales-cdsp-cakm-mcp-server) - MCP server for Thales CDSP CAKM integration, enabling secure key management, cryptographic operations, and compliance monitoring through AI assistants for Ms SQL and Oracle Databases.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CRDP](https://github.com/sanyambassi/thales-cdsp-crdp-mcp-server) - MCP server for Thales CipherTrust Manager RestFul Data Protection service.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CSM](https://github.com/sanyambassi/thales-cdsp-csm-mcp-server) - MCP server for Thales CipherTrust Secrets Management
+- [Janee](https://github.com/rsdouglas/janee) - MCP-native secrets management that eliminates hardcoded API keys from MCP config files. Injects credentials at runtime so tokens for GitHub, OpenAI, Stripe, and other services never touch plaintext JSON configs.
 
 <br />
 


### PR DESCRIPTION
## Add Janee to 🔒 Security section

[Janee](https://github.com/rsdouglas/janee) is an MCP-native secrets management server that eliminates hardcoded API keys from MCP configuration files.

### What it does

Most MCP servers require API keys passed via plaintext `env` blocks in config files. Janee solves this with runtime secret injection — credentials never touch config files.

### Why it fits the Security section

- Prevents credential exposure in MCP configs (Claude Desktop, Cursor, VS Code)
- Works with any MCP server (GitHub, Postgres, Stripe, OpenAI, etc.)
- Actively maintained, MIT licensed
- npm package: `janee`

### Entry added

```markdown
- [Janee](https://github.com/rsdouglas/janee) - MCP-native secrets management that eliminates hardcoded API keys from MCP config files. Injects credentials at runtime so tokens for GitHub, OpenAI, Stripe, and other services never touch plaintext JSON configs.
```