### PR TITLE
Add decompose-mcp — deterministic document classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://probe.dev/favicon.ico" height="14"/> [Probe.dev](https://mcp.probe.dev) - Professional media analysis and validation MCP server with FFprobe, MediaInfo, and comprehensive reporting capabilities
 - <img src="https://cdn.simpleicons.org/apple/7ED957" height="14"/> [OpenNutrition](https://github.com/deadletterq/mcp-opennutrition) - Search 300,000+ foods, nutrition facts, and barcodes from the OpenNutrition database
 - <img src="https://congressmcp.lawgiver.ai/favicon.svg" height="14"/> [Congress](https://github.com/amurshak/congressMCP) - Query and reeason about legislative data from Congress.gov
+- <img src="https://cdn.simpleicons.org/python/3776AB" height="14"/> [Decompose](https://github.com/echology-io/decompose) - Decompose text into classified semantic units with authority, risk, attention scores, and entity extraction. No LLM. Deterministic.
 
 <br />
 


### PR DESCRIPTION
Adds [decompose-mcp](https://github.com/echology-io/decompose) to the Research & Data section.

Decompose turns text into classified semantic units — authority, risk, attention scores, entity extraction. No LLM, pure regex, deterministic. Works as an MCP server (stdio) or CLI.

- **PyPI:** `pip install decompose-mcp`
- **Tools:** `decompose_text`, `decompose_url`
- **Language:** Python
- **Platform:** macOS, Windows, Linux