### PR TITLE
Add CogmemAi to Knowledge Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/notion/787878" height="14"/> [Notion](https://github.com/danhilse/notion_mcp)<sup><sup>1</sup></sup> - Notion API integration for managing personal todo lists and notes
 - <img src="https://cdn.simpleicons.org/notion/787878" height="14"/> [Notion](https://github.com/suekou/mcp-notion-server)<sup><sup>2</sup></sup> - Alternative implementation for Notion API integration
 - <img src="https://cdn.simpleicons.org/apple/999999" height="14"/> [Apple Notes](https://github.com/sirmews/apple-notes-mcp) - Read from local Apple Notes database (macOS only)
+- 🧠 [CogmemAi](https://github.com/hifriendbot/cogmemai-mcp) - Persistent cloud memory for AI coding assistants with semantic search, auto-skills, and knowledge graph.
 - <img src="https://pipedream.com/s.v0/app_Noh9dw/logo/orig" height="14"/> [Slite](https://github.com/fajarmf/slite-mcp) - Model Context Protocol server for Slite integration. Search and retrieve notes, browse note hierarchies, and access content from your Slite workspace.
 - <img src="https://cdn.simpleicons.org/todoist/E44332" height="14"/> [Todoist](https://github.com/abhiz123/todoist-mcp-server) - An MCP server implementation for Todoist, enabling natural language task management.
 - <img src="https://cdn.simpleicons.org/googlekeep/FFBB00" height="14"/> [Google Keep](https://github.com/feuerdev/keep-mcp) - Read, create, update and delete Google Keep notes.


### PR DESCRIPTION
Adds [CogmemAi](https://github.com/hifriendbot/cogmemai-mcp) to the Note Taking / Knowledge Management section.

CogmemAi is a cloud-based MCP server that gives Claude Code persistent memory with semantic search. It extracts facts from coding sessions, stores them as 1536-dim embeddings, and surfaces relevant memories at session start using time-aware ranking.

- npm: `cogmemai-mcp`
- License: MIT
- Published on the Official MCP Registry