### PR TITLE
Add saga-mcp to Workflow Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 > Integration with workflow automation platforms allows AI models to execute workflows and retrieve data back to their systems.
 
 - <img src="https://www.make.com/favicon.ico" height="14"/> [Make](https://github.com/integromat/make-mcp-server)<sup><sup>⭐</sup></sup> - Turn Make scenarios into callable tools for AI assistants.
+- [saga-mcp](https://github.com/spranab/saga-mcp) - A Jira-like project tracker for AI agents. SQLite-backed with 31 tools, full hierarchy (Projects > Epics > Tasks > Subtasks), task dependencies, threaded comments, templates, and natural language dashboard.
 - <img src="https://www.taskade.com/favicon.ico" height="14"/> [Taskade MCP](https://github.com/taskade/mcp)<sup><sup>⭐</sup></sup> - Official Taskade MCP server + OpenAPI → MCP codegen to build AI agent tools from any API and connect Taskade to Claude, Cursor, and more.
 
 <br />


### PR DESCRIPTION
## New Server

**Name:** [saga-mcp](https://github.com/spranab/saga-mcp)
**Category:** Workflow Automation
**Language:** TypeScript
**Scope:** Local

A Jira-like project tracker MCP server for AI agents. SQLite-backed with 31 tools covering the full hierarchy (Projects > Epics > Tasks > Subtasks), task dependencies with auto-block/unblock, threaded comments, reusable task templates with variable substitution, activity logging, and a natural language dashboard summary.

- **npm:** `npx saga-mcp`
- **License:** MIT