### PR TITLE
Add brainstorm-mcp to AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 > Integration with AI and machine learning services.
 
 - <img src="https://agentset.ai/screenshots/logo.png" height="14"/> [Agentset AI](https://github.com/agentset-ai/mcp-server) -  RAG on your data using MCP protocol
+- [brainstorm-mcp](https://github.com/spranab/brainstorm-mcp) - Multi-round AI brainstorming debates between multiple models (GPT, DeepSeek, Groq, Ollama, etc.). Pit different LLMs against each other to explore ideas from diverse perspectives.
 - <img src="https://cdn.simpleicons.org/openai/00A67E" height="14"/> [OpenAI](https://github.com/pierrebrunelle/mcp-server-openai) - Query OpenAI models directly from Claude using MCP protocol
 - <img src="https://cdn.simpleicons.org/openai/00A67E" height="14"/> [OpenAI Compatible Chat](https://github.com/pyroprompts/any-chat-completions-mcp) - Chat with models from OpenAI-compatible APIs (Perplexity, Groq, xAI, etc.)
 - <img src="https://cdn.simpleicons.org/perplexity" height="14"/> [Perplexity](https://github.com/tanigami/mcp-server-perplexity) Chat with Perplexity via MCP


### PR DESCRIPTION
## New Server

**Name:** [brainstorm-mcp](https://github.com/spranab/brainstorm-mcp)
**Category:** AI Services
**Language:** TypeScript
**Scope:** Local

An MCP server for multi-round AI brainstorming debates between multiple models (GPT, DeepSeek, Groq, Ollama, etc.). Enables Claude or any MCP client to orchestrate structured debates where different LLMs argue different perspectives on a topic.

- **npm:** `npx brainstorm-mcp`
- **Repository:** https://github.com/spranab/brainstorm-mcp
- **License:** MIT