### PR TITLE
Add DNA Claude Analysis to Research & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://probe.dev/favicon.ico" height="14"/> [Probe.dev](https://mcp.probe.dev) - Professional media analysis and validation MCP server with FFprobe, MediaInfo, and comprehensive reporting capabilities
 - <img src="https://cdn.simpleicons.org/apple/7ED957" height="14"/> [OpenNutrition](https://github.com/deadletterq/mcp-opennutrition) - Search 300,000+ foods, nutrition facts, and barcodes from the OpenNutrition database
 - <img src="https://congressmcp.lawgiver.ai/favicon.svg" height="14"/> [Congress](https://github.com/amurshak/congressMCP) - Query and reeason about legislative data from Congress.gov
+- <img src="https://api.iconify.design/mdi:dna.svg?color=%234CAF50" height="14"/> [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit using Claude to analyze raw DNA data across 17 categories and generate terminal-style HTML visualization
 
 <br />
 


### PR DESCRIPTION
## Description

Adds [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Research & Data** section.

**DNA Claude Analysis** is a personal genome analysis toolkit that uses Claude to analyze raw DNA data across 17 categories (ancestry, health risks, nutrition, sports/fitness, pharmacogenomics, and more) and generates a terminal-style single-page HTML visualization.

- Placed in the **Research & Data** section alongside other genetic/biology tools like Ancestry
- Follows the existing entry format with inline icon and description