### PR TITLE
Add mcp-config-guard to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CAKM](https://github.com/sanyambassi/thales-cdsp-cakm-mcp-server) - MCP server for Thales CDSP CAKM integration, enabling secure key management, cryptographic operations, and compliance monitoring through AI assistants for Ms SQL and Oracle Databases.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CRDP](https://github.com/sanyambassi/thales-cdsp-crdp-mcp-server) - MCP server for Thales CipherTrust Manager RestFul Data Protection service.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CSM](https://github.com/sanyambassi/thales-cdsp-csm-mcp-server) - MCP server for Thales CipherTrust Secrets Management
+- [mcp-config-guard](https://github.com/KGT24k/mcp-config-guard) - Zero-dependency security linter for MCP configurations. 54 security checks, CVE database (28+ vulnerable packages), OWASP MCP Top 10 mapping, SARIF output, typosquat detection. Supports Claude Code, Claude Desktop, Cursor, Windsurf.
 
 <br />
 


### PR DESCRIPTION
Adds [mcp-config-guard](https://github.com/KGT24k/mcp-config-guard) to the Security section.

Zero-dependency security linter for MCP configurations. 54 security checks, CVE database (28+ vulnerable packages), OWASP MCP Top 10 mapping, SARIF output, typosquat detection.

- Published on PyPI: [`mcp-config-guard`](https://pypi.org/project/mcp-config-guard/)
- 93 tests passing | MIT License