### PR TITLE
Add frostbyte-mcp to Aggregators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
  
 - <img height="12" width="12" src="https://cdn.zapier.com/zapier/images/favicon.ico" alt="Zapier Logo" /> [Zapier](https://zapier.com/mcp) - Connect your AI Agents to 8,000 apps instantly.
 
+- <img height="12" width="12" src="https://api-catalog-three.vercel.app/favicon.ico" alt="Frostbyte Logo" /> [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) - Developer API toolkit with 13 tools — IP geolocation, crypto prices, DNS/WHOIS, screenshots, web scraping, code execution, search, URL shortener, PDF generation, and more. One API key for 40+ services.
+
 <br />
 
 ## 💬 <a name="language"></a>Language & Translation


### PR DESCRIPTION
Adds [frostbyte-mcp](https://github.com/OzorOwn/frostbyte-mcp) to the Aggregators section.

**What it does:** MCP server providing 13 developer tools through a single API key — IP geolocation, crypto prices, DNS/WHOIS lookup, website screenshots, web scraping, code execution (20+ languages), web search, URL shortener, PDF generation, pastebin, data conversion, and domain availability.

**Why Aggregators:** It aggregates 40+ backend APIs behind one MCP server, similar to how Composio/Pipedream/Zapier aggregate multiple services.

- Open source: https://github.com/OzorOwn/frostbyte-mcp
- 13 MCP tools
- Zero dependencies beyond the MCP SDK