### PR TITLE
Add Prediction Market MCP to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/stripe" height="14"/> [Stripe](https://github.com/stripe/agent-toolkit/tree/main)<sup><sup>⭐</sup></sup> - Allows you to integrate with Stripe APIs
 - <img src="https://pub.pbkrs.com/files/202211/TNosrY77nCxm6rtU/logo-without-title.svg" height="14"/> [LongPort OpenAPI](https://github.com/longportapp/openapi/tree/main/mcp)<sup><sup>⭐</sup></sup> - Provides real-time stock market data, provides AI access analysis and trading capabilities through MCP.
 - <img src="https://zbd.gg/favicon.ico" height="14"/> [ZBD](https://github.com/zebedeeio/zbd-payments-typescript-sdk/tree/main/packages/mcp-server)<sup><sup>⭐</sup></sup> - Interact with ZBD's payment processing APIs for instant global payments with Bitcoin and Lightning Network
+- [Prediction Market MCP](https://github.com/reviewmyemails/prediction-market-mcp) - Unified Polymarket + Kalshi prediction market data with cross-platform arbitrage detection, strategy signals, and real-time prices.
 
 <br />
 


### PR DESCRIPTION
Adds [Prediction Market MCP](https://github.com/reviewmyemails/prediction-market-mcp) to the Finance section.

An MCP server providing unified access to Polymarket and Kalshi prediction market data, including:
- Real-time market prices from both platforms
- - Cross-platform arbitrage detection
- - Strategy signals and analytics
- - Published on npm as `prediction-market-mcp`