### PR TITLE
Add A11y Accessibility MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/jira/0052CC" height="14"/> [tom28881/mcp-jira-server](https://github.com/tom28881/mcp-jira-server) - Comprehensive TypeScript MCP server for Jira with 20+ tools covering complete project management workflow: issue CRUD, sprint management, comments/history, attachments, batch operations. Features universal field auto-detection, full Czech/localization support, and date parsing with multiple formats. Created by [Tomáš Gregorovič](https://www.linkedin.com/in/tomáš-g-8423b61a2/).
 - <img src="https://maven.apache.org/images/maven-logo-black-on-white.png" height="14"/>  [Maven Tools MCP](https://github.com/arvindand/maven-tools-mcp) - Maven Central dependency intelligence for JVM build tools (Maven, Gradle, SBT, Mill) with Context7 integration for documentation support.
 - <img src="https://defang.io/favicon.png" height="14" /> [DefangLabs/defang](https://github.com/DefangLabs/defang) - CLI and MCP server for building and deploying Docker Compose-compatible projects to your own AWS, GCP, or DigitalOcean account.
+- ♿ [a11ymcp](https://github.com/ronantakizawa/a11ymcp) - Web accessibility testing MCP server that analyzes URLs and HTML for WCAG 2.0/2.1/2.2 compliance using axe-core. Includes color contrast checking, ARIA validation, and orientation lock detection.
 
 <br />
 


### PR DESCRIPTION
MCP Server: https://github.com/ronantakizawa/a11ymcp

A11y MCP is an MCP server that gives LLMs access to web accessibility testing APIs.

## Features

- **Test web pages**: Test any public URL for accessibility issues with customizable viewport dimensions
- **Test HTML snippets**: Test raw HTML strings for accessibility issues
- **WCAG compliance testing**: Check content against various WCAG standards (2.0, 2.1, 2.2)
- **Customizable tests**: Specify which accessibility tags/standards to test against
- **Rule exploration**: Get information about available accessibility rules
- **Color contrast analysis**: Check color combinations for WCAG compliance
- **ARIA validation**: Test proper usage of ARIA attributes
- **Orientation lock detection**: Identify content that forces specific screen orientations

## Config

```json
{
  "mcpServers": {
    "a11y-accessibility": {
      "command": "npx",
      "args": ["-y", "a11y-mcp-server"]
    }
  }
}
```