### PR TITLE
Add China MCP Servers to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/atlassian/0052CC" height="14"/> [Atlassian](https://github.com/sooperset/mcp-atlassian) - Comprehensive integration with Atlassian suite including Confluence for documentation management and Jira for issue tracking.
 - <img src="https://carbonvoice.app/favicon.ico" height="14"/> [Carbon Voice](https://github.com/PhononX/cv-mcp-server)<sup><sup>⭐</sup></sup> - MCP Server that connects AI Agents to [Carbon Voice](https://getcarbon.app). Create, manage, and interact with voice messages, conversations, direct messages, folders, voice memos, AI actions and more in [Carbon Voice](https://getcarbon.app).
 - <img src="https://m2tg1pnwn0.ufs.sh/f/GMqNN8nd9I8l9tUbmif1CnFX8Baqr7mHeicYu0AULDyNVWJE" height="14"/> [ntfy](https://github.com/gitmotion/ntfy-me-mcp) - An ntfy MCP server for sending/fetching ntfy notifications to your self-hosted ntfy.sh server from AI Agents 📤 (supports secure token auth & more - use with npx or docker!)
+- <img src="https://cdn.simpleicons.org/npm/CB3837" height="14"/> [China MCP Servers](https://github.com/huanglei288766/china-mcp-servers) - MCP servers for Chinese workplace platforms (Feishu/Lark and DingTalk) with messaging, docs, calendar, and approval tools.
 
 <br />
 


### PR DESCRIPTION
## Summary

Adds [China MCP Servers](https://github.com/huanglei288766/china-mcp-servers) to the **Communication** section.

A collection of MCP servers for China's mainstream workplace platforms:

- **Feishu (Lark)**: Send messages, create docs, manage calendars, create tasks
- **DingTalk**: Webhook/work notifications, approvals, calendar management

Both are published as npm packages and work with Claude Code, Cursor, and any MCP-compatible client.

## Changes

- Added China MCP Servers entry to Communication section