### PR TITLE
Add Shopify MCP Server to E-Commerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 - <img src="https://www.mercadolibre.com.ar/favicon.ico" height="14" alt="MercadoLibre Logo" /> [Mercado Libre](https://mcp.mercadolibre.com/) - Mercado Libre's official MCP server, offering tools to interact with our marketplace, simplifying tasks and product integration.
 - <img src="https://shopsavvy.com/favicon.ico" height="14" alt="ShopSavvy Logo" /> **[ShopSavvy](https://github.com/shopsavvy/shopsavvy-mcp-server)**<sup><sup>⭐</sup></sup> - Complete product and pricing data solution for AI assistants. Search for products by barcode/ASIN/URL, access detailed product metadata, access comprehensive pricing data from thousands of retailers, view and track price history, and more. Published as `@shopsavvy/mcp-server`.
+- <img src="https://cdn.shopify.com/static/shopify-favicon.png" height="14" alt="Shopify Logo" /> **[Shopify MCP Server](https://github.com/kgoyal000/shopify-mcp-server)** - Open-source MCP server for Shopify Admin API. Search/update products, query orders, read/write metafields, edit theme assets (Liquid/CSS/JS). Self-hosted with zero vendor lock-in. Works with Claude Code, Cursor, and any MCP client.
 
 <br />
 


### PR DESCRIPTION
Adds an open-source MCP server for Shopify Admin API.

**Features:**
- Search/update products
- Query orders with filtering  
- Read/write metafields
- Edit theme assets (Liquid/CSS/JS)
- Self-hosted, zero vendor lock-in

**Why:** Composio's Shopify integration is commercial. Shopify's official MCP only covers Storefront API (Hydrogen). This fills the gap for Admin API coverage.

**Repo:** https://github.com/kgoyal000/shopify-mcp-server