### PR TITLE
Add claw-mcp-toolkit — 26 tools, 5 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 > Tools for accessing many apps and tools through a single MCP server..
 
+- [claw-mcp-toolkit](https://github.com/ElromEvedElElyon/claw-mcp-toolkit) - All-in-one MCP server with 26 tools across 5 modules (crypto, web, social, finance, productivity). Zero config, MIT license.
+
 - <img height="12" width="12" src="https://github.com/mcpjungle/MCPJungle/blob/main/assets/logo.png" alt="MCPJungle Logo" /> [MCPJungle](https://github.com/mcpjungle/MCPJungle) - Self-hosted MCP Registry and Proxy for enterprise AI Agents.
 
 - <img height="12" width="12" src="https://platform.composio.dev/favicon.ico" alt="Composio Logo"> **[Rube](https://rube.composio.dev)** - Rube is a Model Context Protocol (MCP) server that connects your AI tools to 500+ apps like Gmail, Slack, GitHub, and Notion. Simply install it in your AI client, authenticate once with your apps, and start asking your AI to perform real actions like "Send an email" or "Create a task."


### PR DESCRIPTION
Adds claw-mcp-toolkit to the Aggregators section. All-in-one MCP server with 26 tools across 5 modules (crypto, web, social, finance, productivity). Zero config, MIT license, TypeScript. https://github.com/ElromEvedElElyon/claw-mcp-toolkit