### PR TITLE
Add Art Blocks MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,3 +519,4 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Stephen Akinyemi](https://github.com/appcypher) has waived all copyright and related or neighboring rights to this work.
+- [Art Blocks MCP Server](https://github.com/ArtBlocks/artblocks-mcp) - MCP server for discovering, browsing, and collecting from 500+ on-chain generative art projects on Art Blocks. 21 tools covering project discovery, token metadata, wallet portfolios, minting eligibility, transaction building, PostParams configuration, and advanced GraphQL queries across Ethereum, Base, and Arbitrum.


### PR DESCRIPTION
Adding Art Blocks MCP Server.

MCP server for discovering, browsing, and collecting from 500+ on-chain generative art projects on Art Blocks. 21 tools covering project discovery, token metadata, wallet portfolios, minting eligibility, transaction building, PostParams configuration, and advanced GraphQL queries across Ethereum, Base, and Arbitrum.

**Repository**: https://github.com/ArtBlocks/artblocks-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*