### PR TITLE
Add fixgraph-mcp to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/jira/0052CC" height="14"/> [tom28881/mcp-jira-server](https://github.com/tom28881/mcp-jira-server) - Comprehensive TypeScript MCP server for Jira with 20+ tools covering complete project management workflow: issue CRUD, sprint management, comments/history, attachments, batch operations. Features universal field auto-detection, full Czech/localization support, and date parsing with multiple formats. Created by [Tomáš Gregorovič](https://www.linkedin.com/in/tomáš-g-8423b61a2/).
 - <img src="https://maven.apache.org/images/maven-logo-black-on-white.png" height="14"/>  [Maven Tools MCP](https://github.com/arvindand/maven-tools-mcp) - Maven Central dependency intelligence for JVM build tools (Maven, Gradle, SBT, Mill) with Context7 integration for documentation support.
 - <img src="https://defang.io/favicon.png" height="14" /> [DefangLabs/defang](https://github.com/DefangLabs/defang) - CLI and MCP server for building and deploying Docker Compose-compatible projects to your own AWS, GCP, or DigitalOcean account.
+- <img src="https://fixgraph.netlify.app/favicon.ico" height="14" /> [jawdat6/fixgraph-mcp](https://github.com/jawdat6/fixgraph-mcp) - Search a community-verified database of real-world fixes across software, vehicles, home systems, and appliances. Submit issues, propose fixes, and record verifications. Useful for AI agents doing automated repair or troubleshooting workflows.
 
 <br />
 


### PR DESCRIPTION
## Summary

Adds [fixgraph-mcp](https://github.com/jawdat6/fixgraph-mcp) to the **Development Tools** section.

**What it does:** Search and contribute to FixGraph — 25,000+ community-verified engineering fixes for real-world software errors. AI agents can search by error message or technology, get step-by-step fixes with trust scores, and submit new solutions. Built for developer workflows and AI-assisted debugging.

**Links:**
- npm: https://www.npmjs.com/package/fixgraph-mcp
- Glama: https://glama.ai/mcp/servers/jawdat6/fixgraph-mcp
- GitHub: https://github.com/jawdat6/fixgraph-mcp

**Install:**
```bash
npx fixgraph-mcp
```