### PR TITLE
Add Universal MCP Toolkit to Aggregators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img height="12" width="12" src="https://pipedream.com/favicon.ico" alt="Pipedream Logo" /> [Pipedream](https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol) - Connect with 2,500 APIs with 8,000+ prebuilt tools, and manage servers for your users, in your own app.
  
 - <img height="12" width="12" src="https://cdn.zapier.com/zapier/images/favicon.ico" alt="Zapier Logo" /> [Zapier](https://zapier.com/mcp) - Connect your AI Agents to 8,000 apps instantly.
+- - [Universal MCP Toolkit](https://github.com/Markgatcha/universal-mcp-toolkit) - An all-in-one MCP server aggregating 15+ tools across file system, web search, weather, database, system info, and more. Zero-config npx quickstart, Glama-listed, with 100+ monthly npm downloads.
 
 <br />
 


### PR DESCRIPTION
Hey! I wanted to submit [Universal MCP Toolkit](https://github.com/Markgatcha/universal-mcp-toolkit) for inclusion in the Aggregators section.

## About the project

Universal MCP Toolkit is an all-in-one MCP server that bundles 15+ tools spanning multiple categories — file system operations, web search, weather data, SQLite database, system info, and more. The goal was to give developers a single server they can drop in without juggling a dozen separate MCP installs.

**Key highlights:**
- Zero-config quickstart via `npx universal-mcp-toolkit`
- Listed on [Glama](https://glama.ai) (verified MCP registry)
- 100+ monthly downloads on npm
- MIT licensed, actively maintained
- Full TypeScript with proper MCP SDK integration

## Why Aggregators?

It fits this section well — it's a single MCP server that acts as a unified entry point to many different tools and capabilities, similar in spirit to the other entries here.

Happy to make any adjustments if needed. Thanks for maintaining this list!