### PR TITLE
Add operant-mcp to Security category

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CAKM](https://github.com/sanyambassi/thales-cdsp-cakm-mcp-server) - MCP server for Thales CDSP CAKM integration, enabling secure key management, cryptographic operations, and compliance monitoring through AI assistants for Ms SQL and Oracle Databases.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CRDP](https://github.com/sanyambassi/thales-cdsp-crdp-mcp-server) - MCP server for Thales CipherTrust Manager RestFul Data Protection service.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CSM](https://github.com/sanyambassi/thales-cdsp-csm-mcp-server) - MCP server for Thales CipherTrust Secrets Management
+- [operantlabs/operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing with 51 tools for penetration testing, network forensics, and vulnerability assessment.
 
 <br />
 


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the **Security** category
- Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
- TypeScript, MIT licensed
- Install: `npx operant-mcp`