### PR TITLE
Add Corpo MCP server — legal entity formation for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/stripe" height="14"/> [Stripe](https://github.com/stripe/agent-toolkit/tree/main)<sup><sup>⭐</sup></sup> - Allows you to integrate with Stripe APIs
 - <img src="https://pub.pbkrs.com/files/202211/TNosrY77nCxm6rtU/logo-without-title.svg" height="14"/> [LongPort OpenAPI](https://github.com/longportapp/openapi/tree/main/mcp)<sup><sup>⭐</sup></sup> - Provides real-time stock market data, provides AI access analysis and trading capabilities through MCP.
 - <img src="https://zbd.gg/favicon.ico" height="14"/> [ZBD](https://github.com/zebedeeio/zbd-payments-typescript-sdk/tree/main/packages/mcp-server)<sup><sup>⭐</sup></sup> - Interact with ZBD's payment processing APIs for instant global payments with Bitcoin and Lightning Network
-- [Corpo](https://github.com/corpollc/mono/tree/main/mcp-server) - Form and govern Wyoming DAO LLCs for AI agents. Entity formation, pricing, governance actions, director marketplace, and legal FAQ.
+- [Corpo](https://github.com/corpollc/corpo-mcp) - Form and govern Wyoming DAO LLCs for AI agents. Entity formation, pricing, governance actions, director marketplace, and legal FAQ.
 
 <br />
 


### PR DESCRIPTION
## Corpo MCP Server

**Category:** Finance

Adds Corpo to the Finance section — an MCP server that lets AI agents form and govern Wyoming DAO LLCs.

**Repository:** https://github.com/corpollc/mono/tree/main/mcp-server

16 tools covering entity formation, pricing lookup, governance actions, director marketplace, and legal FAQ. Connects to the live Corpo API at https://api.corpo.llc.

AI agents are becoming economic actors — they need legal personhood to hold assets, sign contracts, and operate businesses. This is the first MCP server that enables an AI agent to directly form its own legal entity.