### PR TITLE
Add Strale capabilities to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img height="12" width="12" src="https://platform.composio.dev/favicon.ico" alt="Composio Logo"> **[Rube](https://rube.composio.dev)** - Rube is a Model Context Protocol (MCP) server that connects your AI tools to 500+ apps like Gmail, Slack, GitHub, and Notion. Simply install it in your AI client, authenticate once with your apps, and start asking your AI to perform real actions like "Send an email" or "Create a task."
 
 - <img height="12" width="12" src="https://pipedream.com/favicon.ico" alt="Pipedream Logo" /> [Pipedream](https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol) - Connect with 2,500 APIs with 8,000+ prebuilt tools, and manage servers for your users, in your own app.
+
+- [Strale](https://strale.dev) - 250+ quality-scored capabilities for AI agents: company data across 27 countries, compliance checks (KYB, AML, sanctions, GDPR), financial validation, web intelligence, document extraction, developer tools, and data processing. Every capability independently tested with Strale Quality Score (SQS). Free tier available.
  
 - <img height="12" width="12" src="https://cdn.zapier.com/zapier/images/favicon.ico" alt="Zapier Logo" /> [Zapier](https://zapier.com/mcp) - Connect your AI Agents to 8,000 apps instantly.
 


### PR DESCRIPTION
Use the same PR description as punkpeye. Here it is again — copy and paste this when you create the PR: ## Add Strale MCP Server

Strale provides 250+ quality-scored capabilities for AI agents across 7 categories, accessible via MCP with Streamable HTTP transport.

### Capability categories
- **Company data** — business registry lookups across 27 countries (EU, Nordic, UK, US, APAC)
- **Compliance & KYB** — sanctions screening, adverse media, GDPR checks, EU AI Act classification, data protection authority lookups
- **Financial validation** — IBAN, VAT, LEI, BIC/SWIFT validation, exchange rates, SEPA readiness
- **Web intelligence** — web extraction, page speed tests, SSL checks, DNS lookups, domain reputation, cookie scanning
- **Document extraction** — invoice, receipt, contract, resume parsing, PDF extraction
- **Developer tools** — CVE lookup, dependency audit, code review, Dockerfile/GitHub Actions generation, regex, SQL generation
- **Data processing** — JSON/CSV/XML transforms, text classification, sentiment analysis, translation, summarization

### Trust scoring
Every capability has a Strale Quality Score (SQS) — a dual-profile model with Quality Profile (correctness, schema compliance, error handling, edge cases) and Reliability Profile (availability, success rate, upstream health, latency), combined via a 5×5 matrix producing grades A through E.

### Access
- **MCP**: https://api.strale.io/mcp (Streamable HTTP)
- **Also supports**: A2A, REST API, x402 micropayments
- **Free tier**: strale_search + iban-validate work without API key
- **npm**: https://www.npmjs.com/package/strale-mcp
- **Glama**: https://glama.ai/mcp/servers/strale-io/strale
- **Homepage**: https://strale.dev
- **GitHub**: https://github.com/strale-io/strale