### PR TITLE
Add Agent Module MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 > Access to research papers, genetic data, and specialized datasets.
 
+- ☁️ [Agent Module](https://github.com/AgentModule/mcp) - Agent-native knowledge infrastructure for autonomous agents. Deterministic, vertical-specific knowledge bases delivered via MCP. EU AI Act compliance modules included with every membership. Free 24hr trial. 7 MCP tools.
 - <img src="https://cdn.simpleicons.org/arxiv/B31B1B" height="14"/> [ArXiv](https://github.com/blazickjp/arxiv-mcp-server) - Search ArXiv research papers
 - <img src="https://api.iconify.design/mdi:dna.svg?color=%23E34234" height="14"/> [Ancestry](https://github.com/reeeeemo/ancestry-mcp) - Read .ged files and genetic data
 - <img src="https://probe.dev/favicon.ico" height="14"/> [Probe.dev](https://mcp.probe.dev) - Professional media analysis and validation MCP server with FFprobe, MediaInfo, and comprehensive reporting capabilities


### PR DESCRIPTION
Agent Module — agent-native knowledge infrastructure providing deterministic, vertical-specific knowledge bases via MCP for autonomous agent consumption. EU AI Act compliance modules, 7 MCP tools, free trial available.

Public repo: https://github.com/AgentModule/mcp