### PR TITLE
Add LystBot to Note Taking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/apple/999999" height="14"/> [Apple Notes](https://github.com/sirmews/apple-notes-mcp) - Read from local Apple Notes database (macOS only)
 - <img src="https://pipedream.com/s.v0/app_Noh9dw/logo/orig" height="14"/> [Slite](https://github.com/fajarmf/slite-mcp) - Model Context Protocol server for Slite integration. Search and retrieve notes, browse note hierarchies, and access content from your Slite workspace.
 - <img src="https://cdn.simpleicons.org/todoist/E44332" height="14"/> [Todoist](https://github.com/abhiz123/todoist-mcp-server) - An MCP server implementation for Todoist, enabling natural language task management.
+- [LystBot](https://github.com/TourAround/LystBot) - AI-powered list management with full MCP server. Your AI agent creates grocery lists, todos, and packing lists, checks items off, and shares with family. Free iOS + Android app.
 - <img src="https://cdn.simpleicons.org/googlekeep/FFBB00" height="14"/> [Google Keep](https://github.com/feuerdev/keep-mcp) - Read, create, update and delete Google Keep notes.
 
 <br />


### PR DESCRIPTION
Adds [LystBot](https://github.com/TourAround/LystBot) to the Note Taking section.

LystBot is an MCP server for AI-powered list management. Your AI agent creates grocery lists, todos, and packing lists, checks items off, and shares with family/friends.

- npm: https://www.npmjs.com/package/lystbot
- Free iOS + Android app: https://lystbot.com
- 10 MCP tools: list_lists, get_list, create_list, delete_list, add_items, check_item, uncheck_item, remove_item, share_list, join_list