### PR TITLE
Add SettleGrid Discovery to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/stripe" height="14"/> [Stripe](https://github.com/stripe/agent-toolkit/tree/main)<sup><sup>⭐</sup></sup> - Allows you to integrate with Stripe APIs
 - <img src="https://pub.pbkrs.com/files/202211/TNosrY77nCxm6rtU/logo-without-title.svg" height="14"/> [LongPort OpenAPI](https://github.com/longportapp/openapi/tree/main/mcp)<sup><sup>⭐</sup></sup> - Provides real-time stock market data, provides AI access analysis and trading capabilities through MCP.
 - <img src="https://zbd.gg/favicon.ico" height="14"/> [ZBD](https://github.com/zebedeeio/zbd-payments-typescript-sdk/tree/main/packages/mcp-server)<sup><sup>⭐</sup></sup> - Interact with ZBD's payment processing APIs for instant global payments with Bitcoin and Lightning Network
+- [SettleGrid Discovery](https://github.com/lexwhiting/settlegrid) - Settlement layer for AI agent payments. Discover monetized tools, per-call billing across 10 protocols, Stripe Connect payouts, 0% fees on free tier. `npx @settlegrid/discovery`
 
 <br />
 


### PR DESCRIPTION
Adds SettleGrid Discovery MCP server. Settlement layer for AI agent payments — discover monetized tools, per-call billing, 10 protocols. npm: @settlegrid/discovery | Website: settlegrid.ai