### PR TITLE
Add Web Resource Ledger (web evidence capture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CAKM](https://github.com/sanyambassi/thales-cdsp-cakm-mcp-server) - MCP server for Thales CDSP CAKM integration, enabling secure key management, cryptographic operations, and compliance monitoring through AI assistants for Ms SQL and Oracle Databases.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CRDP](https://github.com/sanyambassi/thales-cdsp-crdp-mcp-server) - MCP server for Thales CipherTrust Manager RestFul Data Protection service.
 - <img src="https://cdn.worldvectorlogo.com/logos/thales-1.svg" height="14"/> [CSM](https://github.com/sanyambassi/thales-cdsp-csm-mcp-server) - MCP server for Thales CipherTrust Secrets Management
+- <img src="https://docs.webresourceledger.com/favicon.ico" height="14"/> [Web Resource Ledger](https://github.com/benpeter/web-resource-ledger) - Capture web pages as cryptographically signed, tamper-evident evidence. Ed25519 signatures, RFC 3161 timestamps, WACZ archives. MCP tools for capture, retrieval, and verification.
 
 <br />
 


### PR DESCRIPTION
## Web Resource Ledger

Adds [Web Resource Ledger](https://github.com/benpeter/web-resource-ledger) to the Security section.

WRL captures web pages as verifiable, tamper-evident evidence. Every capture produces a screenshot, rendered HTML, HTTP headers, and a cryptographically signed WACZ bundle with Ed25519 signature and RFC 3161 timestamp.

**MCP tools:** `capture_url`, `get_capture`, `list_captures`, `verify_capture`
**Transport:** Streamable HTTP at `https://api.webresourceledger.com/mcp`
**Docs:** https://docs.webresourceledger.com/mcp/