### PR TITLE
Add CryptoScholar to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/stripe" height="14"/> [Stripe](https://github.com/stripe/agent-toolkit/tree/main)<sup><sup>⭐</sup></sup> - Allows you to integrate with Stripe APIs
 - <img src="https://pub.pbkrs.com/files/202211/TNosrY77nCxm6rtU/logo-without-title.svg" height="14"/> [LongPort OpenAPI](https://github.com/longportapp/openapi/tree/main/mcp)<sup><sup>⭐</sup></sup> - Provides real-time stock market data, provides AI access analysis and trading capabilities through MCP.
 - <img src="https://zbd.gg/favicon.ico" height="14"/> [ZBD](https://github.com/zebedeeio/zbd-payments-typescript-sdk/tree/main/packages/mcp-server)<sup><sup>⭐</sup></sup> - Interact with ZBD's payment processing APIs for instant global payments with Bitcoin and Lightning Network
+- <img src="https://cdn.simpleicons.org/bitcoin/F7931A" height="14"/> [CryptoScholar](https://github.com/cryptographer11/cryptoscholar) - Live crypto technical analysis MCP server. Computes EMA, RSI, MACD, ADX, ATR, Bollinger Bands, and a Trend Strength Score (TSS) via CoinGecko free API. Includes Claude AI-powered bull/bear debate synthesis.
 
 <br />
 


### PR DESCRIPTION
## CryptoScholar

[CryptoScholar](https://github.com/cryptographer11/cryptoscholar) is an open-source MCP server that brings live crypto technical analysis into Claude.

**Tools:**
- `analyze_coin` — EMA-20/50/200, RSI-14, MACD, ADX, ATR, Bollinger Bands, Historical Volatility, RS vs BTC, Trend Strength Score (TSS), volatility regime
- `rank_coins` — TSS-ranked comparison across multiple symbols
- `debate` — Claude AI bull/bear synthesis grounded in live TA data

**Data source:** CoinGecko free API (no key required). Only `ANTHROPIC_API_KEY` needed for the debate tool.

Fits alongside CoinMarket and DexPaprika in the Finance section.