### PR TITLE
feat: add Flow Studio to Workflow Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 > Integration with workflow automation platforms allows AI models to execute workflows and retrieve data back to their systems.
 
+- <img src="https://flowstudio.app/favicon.ico" height="14"/> [Flow Studio](https://github.com/ninihen1/FlowStudio-MCP) - Read, debug, build, and monitor Power Automate cloud flows via AI agents.
 - <img src="https://www.make.com/favicon.ico" height="14"/> [Make](https://github.com/integromat/make-mcp-server)<sup><sup>⭐</sup></sup> - Turn Make scenarios into callable tools for AI assistants.
 - <img src="https://www.taskade.com/favicon.ico" height="14"/> [Taskade MCP](https://github.com/taskade/mcp)<sup><sup>⭐</sup></sup> - Official Taskade MCP server + OpenAPI → MCP codegen to build AI agent tools from any API and connect Taskade to Claude, Cursor, and more.
 


### PR DESCRIPTION
Adds [Flow Studio](https://mcp.flowstudio.app) to the **Workflow Automation** category.

Flow Studio MCP server enables AI agents to read, debug, build, and monitor Microsoft Power Automate cloud flows. Works with Copilot, Claude, and any MCP-compatible agent.

- **Endpoint**: `https://mcp.flowstudio.app/mcp`
- **Auth**: API Key (`x-api-key` header)
- **Repo**: https://github.com/ninihen1/FlowStudio-MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)