### PR TITLE
Add AKF Trust Metadata to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 
 > Tools for security needs. Enables securing code, finding vulnerabilies.
 
-- <img src="https://akf.dev/favicon.svg" height="14"/> [AKF Trust Metadata](https://github.com/HMAKT99/AKF) - 9 MCP tools for stamping, auditing, and verifying trust metadata on AI-generated content. Trust scores, source provenance, and compliance auditing (EU AI Act, SOX, HIPAA, NIST).
+- <img src="https://akf.dev/favicon.svg" height="14"/> [AKF — The AI Native File Format](https://github.com/HMAKT99/AKF) - EXIF for AI. Embeds trust scores, source provenance, and compliance metadata into 20+ file formats. 9 MCP tools: stamp, inspect, trust, audit, scan, embed, extract, detect.
 - <img src="https://semgrep.dev/favicon.ico" height="14"/> [Semgrep](https://github.com/semgrep/mcp) - A MCP server for using [Semgrep](https://github.com/semgrep/semgrep) to scan code for security vulnerabilities.
 - <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Microsoft_Entra_ID_color_icon.svg/120px-Microsoft_Entra_ID_color_icon.svg.png" height="14"/> [Microsoft Entra ID](https://github.com/hieuttmmo/entraid-mcp-server) - A MCP server for interacting with EntraID through Microsoft Graph API. It is designed for extensibility, maintainability, and security, supporting advanced queries for users, sign-in logs, MFA status, privileged users and more.
 - <img src="https://www.netwrix.com/favicon.ico" height="14"/> [Netwrix](https://github.com/netwrix/mcp-server-naa)<sup><sup>⭐</sup></sup> - A FastMCP-based server for [Netwrix Access Analyzer](https://www.netwrix.com/access-analyzer.html) data analysis, designed for enhanced data analysis capabilities.


### PR DESCRIPTION
Adds [AKF Trust Metadata](https://github.com/HMAKT99/AKF) to the Security section.

**What it does:** 9 MCP tools for stamping, auditing, and verifying trust metadata on AI-generated content. Trust scores, source provenance, and compliance auditing (EU AI Act, SOX, HIPAA, NIST).

**Install:**
```json
{
  "mcpServers": {
    "akf": {
      "command": "python",
      "args": ["-m", "mcp_server_akf"]
    }
  }
}
```

**Tools:** stamp, read, inspect, trust, audit, scan, embed, extract, detect

- Open source (MIT)
- Docs: https://akf.dev
- Demo: https://huggingface.co/spaces/HANAKT19/akf